### PR TITLE
Add releasing guide and necessary tools.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contribution Guide
+
+## Releasing a new version
+
+### Building the new version
+
+Increment the version in `pyproject.toml`.
+
+Install development dependencies:
+```bash
+pip install ".[dev]"
+```
+
+Build a source and a wheel distributions:
+```bash
+rm -rf ./dist # clean the build directory if necessary
+python -m build
+```
+
+### Publishing to Test Pypi
+
+Login to Test PyPi. Create a new account if you don't have it yet
+and ask to be added as a collaborator for Anonymeter.
+
+Get the token from [Test PyPi](https://test.pypi.org/manage/account/#api-tokens)
+and save it as suggested to `$HOME/.pypirc`:
+```toml
+[testpypi]
+  username = __token__
+  password = YOUR_TOKEN_HERE
+```
+
+Upload the artifacts to Test PyPi:
+```bash
+twine upload --repository testpypi dist/*
+```
+
+Test that the package installs and works properly. For example,
+you can create a new virtualenv and try to install the package there.
+```bash
+mkdir ~/test-anonymeter # create some test directory
+cd ~/test-anonymeter
+python -m venv .venv # create new virtual env
+source .venv/bin/activate
+asdf reshim python # in case you use asdf
+pip install --upgrade pip
+pip install --index-url https://test.pypi.org/simple anonymeter==NEW_VERSION
+```
+
+You can check that anonymeter is working by running it against the original tests.
+For example, if you had Anonymeter repository checked out in `~/code/anonymeter`::
+```
+ln -s ~/code/anonymeter/tests ~/test-anonymeter/tests
+pip install pytest
+python -m pytest
+```
+
+### Publishing to PyPi
+
+Once you tested the package with Test PyPi, you're ready to publish to
+the original PyPi.
+
+Login to PyPi. Create a new account if you don't have it yet
+and ask to be added as a collaborator for Anonymeter.
+
+Get the token from PyPi: https://pypi.org/manage/account/token
+and add it as suggested to `$HOME/.pypirc`:
+```toml
+[pypi]
+  username = __token__
+  password = YOUR_TOKEN_HERE
+```
+
+Upload the artifacts to PyPi:
+```bash
+twine upload dist/*
+```
+
+### Publish the new release to GitHub
+
+Commit the version update:
+
+```bash
+git commit -m "Version bump -> NEW_VERSION" pyproject.toml
+```
+
+Tag the source: `git tag NEW_VERSION`.
+
+Push commit and tag: `git push --tags origin main`.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ guessing in order for the results to be trusted.
 
 Anonymeter requires Python 3.8.x, 3.9.x or 3.10.x installed.
 
+### From PyPi
+
+Run:
+```
+pip install anonymeter
+```
+
+### Locally
+
 Clone the Anonymeter repository:
 
 ```shell
@@ -60,7 +69,11 @@ This should be installed as part of the `notebooks` dependencies. If you haven't
 install them by executing:
 
 ```shell
-pip install ".[notebooks]"
+pip install ".[notebooks]" # for local installation
+
+# or
+
+pip install anonymeter[notebooks] # for PyPi installation
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,18 +37,27 @@ notebooks = [
 ]
 
 dev = [
+    # Linting and code checks
     "flake8~=5.0",
     "flake8-docstrings~=1.6.0",
     "flake8-eradicate~=1.4.0",
     "flake8-broken-line~=0.5",
     "flake8-bugbear~=23.2",
-    "isort~=5.10",
-    "black~=22.10",
     "pre-commit==2.20.0",
-    "pytest==7.1.2",
-    "pytest-cov==3.0.0",
     "mypy==0.961",
     "pytest-mypy==0.9.1",
+
+    # Code formatting
+    "isort~=5.10",
+    "black~=22.10",
+
+    # Testing
+    "pytest==7.1.2",
+    "pytest-cov==3.0.0",
+
+    # Building and packaging
+    "build~=0.10",
+    "twine~=4.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
This introduces the bare minimum instructions for releasing Anonymeter to PyPi. No release management or CI/CD integration for now.

Closes #10 