### PR TITLE
Update dependencies and development tools

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,6 +16,9 @@ jobs:
         # We test only the minimum and the maximum supported versions of python
         python-version: ["3.8", "3.11"]
         pandas-version: ["1.5", "2.1"]
+        exclude:
+        - python-version: "3.8"
+          pandas-version: "2.1"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # We test only the minimum and the maximum supported versions of python
         python-version: ["3.8", "3.11"]
-        pandas-version: ["1.5", "2.1"]
+        pandas-version: ["1.4", "2.1"]
         exclude:
         - python-version: "3.8"
           pandas-version: "2.1"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Python package
 
 on:
@@ -16,7 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        # We test only the minimum and the maximum supported versions of python
+        python-version: ["3.8", "3.11"]
+        pandas-version: ["1.5", "2.1"]
 
     steps:
     - uses: actions/checkout@v2
@@ -27,13 +26,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e '.[build,dev]'
-    - name: Lint with flake8
+        pip install pandas~=${{ matrix.pandas-version }}
+        pip install -e '.[dev]'
+    - name: Ruff Ruff
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        ruff ./src ./tests
+    - name: mypy check
+      run: |
+        mypy ./src ./tests
     - name: Test with pytest
       run: |
         pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,26 +14,14 @@ repos:
     hooks:
       - id: git-check
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
+    hooks:
+      - id: ruff
+      - id: ruff-format
+
   - repo: local
     hooks:
-      - id: black
-        name: black
-        language: system
-        entry: black
-        types: [python]
-
-      - id: isort
-        name: isort
-        language: system
-        entry: isort
-        types: [python]
-
-      - id: flake8
-        name: flake8
-        language: system
-        entry: flake8
-        types: [python]
-
       - id: mypy
         name: mypy
         language: system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 description = "Measure singling out, linkability, and inference risk for synthetic data."
 readme = "README.md"
-requires-python = "<3.11, >3.7" # limited by Numba support
+requires-python = "<3.12, >3.7" # limited by Numba support
 license = {file = "LICENSE.md"}
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -23,10 +23,10 @@ classifiers = [
 
 dependencies = [
     "scikit-learn~=1.2",
-    "numpy >=1.11,<1.24",
-    "pandas~=1.4",
+    "numpy >=1.22, <1.27", # limited by Numba support
+    "pandas>=1.4",
     "joblib~=1.2",
-    "numba~=0.56",
+    "numba~=0.58",
 ]
 
 [project.optional-dependencies]
@@ -37,22 +37,15 @@ notebooks = [
 ]
 
 dev = [
-    # Linting and code checks
-    "flake8~=5.0",
-    "flake8-docstrings~=1.6.0",
-    "flake8-eradicate~=1.4.0",
-    "flake8-broken-line~=0.5",
-    "flake8-bugbear~=23.2",
-    "pre-commit==2.20.0",
-    "mypy~=1.2.0",
+    # Linting and formatting
+    "ruff~=0.1.14",
+    "mypy~=1.8.0",
 
-    # Code formatting
-    "isort~=5.10",
-    "black~=22.10",
+    # Pre-commit checks
+    "pre-commit~=3.6",
 
     # Testing
-    "pytest==7.1.2",
-    "pytest-cov==3.0.0",
+    "pytest~=7.4",
 
     # Building and packaging
     "build~=0.10",
@@ -64,58 +57,62 @@ dev = [
 "Bug Tracker" = "https://github.com/statice/anonymeter/issues"
 "Changelog" = "https://github.com/statice/anonymeter/blob/main/CHANGELOG.md"
 
-[tool.isort]
-profile = "black"
-known_first_party = "anonymeter"
-line_length = 120
-skip = [
-    ".git",
-    ".vscode",
-    ".venv",
-    ".pytest_cache",
-    ".mypy_cache",
-    "__init__.py",
-    "build",
-    "dist",
-    "htmlcov",
+[tool.ruff]
+# https://docs.astral.sh/ruff/configuration/
+
+line-length = 120
+
+select = [
+    "B",    # https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
+    "C4",   # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
+    "E4",   # https://docs.astral.sh/ruff/rules/#error-e
+    "E7",
+    "E9",
+    "NPY",
+    "F",    # https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "I001", # isort
+    "W",    # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "YTT",  # https://docs.astral.sh/ruff/rules/#flake8-2020-ytt
+    "PGH",  # https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh
+    "PIE",  # https://docs.astral.sh/ruff/rules/#flake8-pie-pie
+    "UP",   # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "RUF",
 ]
 
-[tool.black]
-line-length = 120
-multi-line-output = 3
-include-trailing-comma = true
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.ruff.isort]
+known-first-party = ["anonymeter"]
+forced-separate = ["tests"]
+
+[tool.ruff.lint]
+extend-select = ["NPY201"]
+preview = true
 
 [tool.mypy]
-disallow_untyped_defs = false
 ignore_missing_imports = true
 follow_imports = "silent"
 show_column_numbers = true
+check_untyped_defs = true
 show_error_context = false
 exclude = [
     "docs",
-    "tests",
     "build",
     "dist",
-    "htmlcov"
 ]
-
-# Explicitly blacklist modules in use that don't have type stubs
-[mypy-pandas]
-ignore_missing_imports=true
-
-[mypy-numpy]
-ignore_missing_imports=true
 
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore::UserWarning",
     "ignore::FutureWarning",
-    "ignore::PendingDeprecationWarning"
+    "ignore::PendingDeprecationWarning",
 ]
 testpaths = [
-    "tests"
+    "tests",
 ]
 pythonpath = [
-    "src"
+    "src",
 ]
 xfail_strict=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
     "mypy~=1.8.0",
 
     # Pre-commit checks
-    "pre-commit~=3.6",
+    "pre-commit~=3.5",
 
     # Testing
     "pytest~=7.4",

--- a/src/anonymeter/evaluators/__init__.py
+++ b/src/anonymeter/evaluators/__init__.py
@@ -6,4 +6,4 @@ from anonymeter.evaluators.inference_evaluator import InferenceEvaluator
 from anonymeter.evaluators.linkability_evaluator import LinkabilityEvaluator
 from anonymeter.evaluators.singling_out_evaluator import SinglingOutEvaluator
 
-__all__ = ["SinglingOutEvaluator", "LinkabilityEvaluator", "InferenceEvaluator"]
+__all__ = ["InferenceEvaluator", "LinkabilityEvaluator", "SinglingOutEvaluator"]

--- a/src/anonymeter/evaluators/linkability_evaluator.py
+++ b/src/anonymeter/evaluators/linkability_evaluator.py
@@ -6,6 +6,7 @@ import logging
 from typing import Dict, List, Optional, Set, Tuple, cast
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 from anonymeter.neighbors.mixed_types_kneighbors import MixedTypeKNeighbors
@@ -32,7 +33,7 @@ class LinkabilityIndexes:
 
     """
 
-    def __init__(self, idx_0: np.ndarray, idx_1: np.ndarray):
+    def __init__(self, idx_0: npt.NDArray, idx_1: npt.NDArray):
         self._idx_0 = idx_0
         self._idx_1 = idx_1
 
@@ -89,13 +90,13 @@ def _count_links(links: Dict[int, Set[int]]) -> int:
     """Count links."""
     linkable: Set[int] = set()
 
-    for ori_idx in links.keys():
+    for ori_idx in links:
         linkable = linkable | {ori_idx}
 
     return len(linkable)
 
 
-def _random_links(n_synthetic: int, n_attacks: int, n_neighbors: int) -> np.ndarray:
+def _random_links(n_synthetic: int, n_attacks: int, n_neighbors: int) -> npt.NDArray:
     rng = np.random.default_rng()
 
     return np.array([rng.choice(n_synthetic, size=n_neighbors, replace=False) for _ in range(n_attacks)])
@@ -108,7 +109,7 @@ def _random_linkability_attack(n_synthetic: int, n_attacks: int, n_neighbors: in
     return LinkabilityIndexes(idx_0=idx_0, idx_1=idx_1)
 
 
-def _find_nn(syn: pd.DataFrame, ori: pd.DataFrame, n_jobs: int, n_neighbors: int) -> np.ndarray:
+def _find_nn(syn: pd.DataFrame, ori: pd.DataFrame, n_jobs: int, n_neighbors: int) -> npt.NDArray:
     nn = MixedTypeKNeighbors(n_jobs=n_jobs, n_neighbors=n_neighbors)
 
     if syn.ndim == 1:

--- a/src/anonymeter/preprocessing/transformations.py
+++ b/src/anonymeter/preprocessing/transformations.py
@@ -43,6 +43,8 @@ def _scale_numerical(df1: pd.DataFrame, df2: pd.DataFrame) -> Tuple[pd.DataFrame
 
     df1_scaled = df1.apply(lambda x: x / ranges[x.name])
     df2_scaled = df2.apply(lambda x: x / ranges[x.name])
+    if isinstance(df1_scaled, pd.Series) or isinstance(df2_scaled, pd.Series):
+        raise RuntimeError("Unexpected error: scaling resulted in a Series.")
 
     return df1_scaled, df2_scaled
 

--- a/src/anonymeter/stats/confidence.py
+++ b/src/anonymeter/stats/confidence.py
@@ -48,7 +48,10 @@ class SuccessRate(NamedTuple):
 
 def probit(confidence_level: float) -> float:
     """Compute the probit for the given confidence level."""
-    return norm.ppf(0.5 * (1.0 + confidence_level))
+    result = norm.ppf(0.5 * (1.0 + confidence_level))
+    if not isinstance(result, float):
+        raise RuntimeError("Unexpected error: probit resulted in a non-float value.")
+    return result
 
 
 def success_rate(n_total: int, n_success: int, confidence_level: float) -> SuccessRate:
@@ -152,9 +155,9 @@ def bind_value(point_estimate: float, error_bound: float) -> PrivacyRisk:
     Returns
     -------
     float
-        Point estimate respecting the bounds 0–1 or 0–100.
+        Point estimate respecting the bounds 0-1 or 0-100.
     Tuple[float, float]
-        Asymmetric confidence interval respecting the bounds 0–1 or 0–100.
+        Asymmetric confidence interval respecting the bounds 0-1 or 0-100.
 
     """
     bound_point = min(max(point_estimate, 0.0), 1.0)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -35,6 +35,6 @@ def get_adult(which: str, n_samples: Optional[int] = None) -> pd.DataFrame:
     elif which == "syn":
         fname = "adults_syn.csv"
     else:
-        return ValueError(f"Invalid value {which} for parameter `which`. Available are: 'ori' or 'syn'.")
+        raise ValueError(f"Invalid value {which} for parameter `which`. Available are: 'ori' or 'syn'.")
 
     return pd.read_csv(os.path.join(TEST_DIR_PATH, "datasets", fname), nrows=n_samples)

--- a/tests/test_inference_evaluator.py
+++ b/tests/test_inference_evaluator.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from anonymeter.evaluators.inference_evaluator import InferenceEvaluator, evaluate_inference_guesses
+
 from tests.fixtures import get_adult
 
 

--- a/tests/test_mixed_types_kneigbors.py
+++ b/tests/test_mixed_types_kneigbors.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from anonymeter.neighbors.mixed_types_kneighbors import MixedTypeKNeighbors, gower_distance
+
 from tests.fixtures import get_adult
 
 rng = np.random.default_rng()
@@ -45,10 +46,12 @@ def test_mixed_type_kNN_shape(n_neighbors, n_queries):
     df = get_adult("ori", n_samples=10)
     nn = MixedTypeKNeighbors(n_neighbors=n_neighbors).fit(df)
     ids = nn.kneighbors(df.head(n_queries))
+    assert isinstance(ids, np.ndarray)
     assert ids.shape == (n_queries, n_neighbors)
 
     nn = MixedTypeKNeighbors().fit(df)
     ids = nn.kneighbors(df.head(n_queries), n_neighbors=n_neighbors)
+    assert isinstance(ids, np.ndarray)
     assert ids.shape == (n_queries, n_neighbors)
 
 

--- a/tests/test_singling_out_evaluator.py
+++ b/tests/test_singling_out_evaluator.py
@@ -14,6 +14,7 @@ from anonymeter.evaluators.singling_out_evaluator import (
     singling_out_probability_integral,
     univariate_singling_out_queries,
 )
+
 from tests.fixtures import get_adult
 
 
@@ -101,7 +102,7 @@ def test_singling_out_risk_estimate(confidence_level, mode):
     ori = get_adult("ori", 10)
     soe = SinglingOutEvaluator(ori=ori, syn=ori, n_attacks=5)
     soe.evaluate(mode=mode)
-    risk, ci = soe.risk(confidence_level=confidence_level)
+    _, ci = soe.risk(confidence_level=confidence_level)
     np.testing.assert_allclose(ci[1], 1.0)
 
 


### PR DESCRIPTION
This PR updates the dependencies, relaxes the version constraints and updates the development tools and workflows.

Changes:
- numba is updated to 0.58 to allow for the newer numpy version
- numpy version range is adapted accordingly to numba's requirements
- python 3.11 is allowed
- pandas version is relaxed to allow for pandas >= 2
  * added additional CI pipeline for pandas 2
- mypy is updated and enabled on CI
  * all type hints are now fixed
- black, flake8 and isort are replaced by ruff
  * the entire codebase is now formatted and linted with ruff
  * the CI pipeline is updated accordingly

Closes #25 