### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2024-02-02
+
+### Changed
+
+- numba is updated to 0.58 to allow for the newer numpy version
+- numpy version range is adapted accordingly to numba's requirements
+- python 3.11 is allowed
+- pandas version is relaxed to allow for pandas >= 2
+  * added additional CI pipeline for pandas 2
+
+### Fixed
+
+- singling out evaluators getting stuck on multivariate queries
+
 ## [0.0.2] - 2023-07-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anonymeter"
-version = "0.0.2"
+version = "1.0.0"
 authors = [
   { name="Statice GmbH", email="hello@statice.ai" },
 ]


### PR DESCRIPTION
Prepare for the 1.0.0 release.

I went for the `1.0.0` version as anonymeter was used for a while and the current state can be considered stable. Additionally, it will be useful to have the first major release in case we plan to add more changes to anonymeter in the future. 