### PR TITLE
Avoid false positives in duplicate query detection (fixes #35)

### DIFF
--- a/src/anonymeter/evaluators/singling_out_evaluator.py
+++ b/src/anonymeter/evaluators/singling_out_evaluator.py
@@ -39,7 +39,7 @@ def _query_from_record(record: pd.Series, dtypes: pd.Series, columns: List[str],
     """Construct a query from the attributes in a record."""
     query = []
 
-    for col in columns:
+    for col in sorted(columns):
         if pd.isna(record[col]):
             item = ".isna()"
         elif is_bool_dtype(dtypes[col]):
@@ -84,7 +84,7 @@ def _random_query(unique_values: Dict[str, List[Any]], cols: List[str]):
     """Generate a random query using given columns."""
     query = []
 
-    for col in cols:
+    for col in sorted(cols):
         values = unique_values[col]
         val = rng.choice(values)
 
@@ -238,13 +238,12 @@ class UniqueSinglingOutQueries:
             Dataframe on which the queries need to single out.
 
         """
-        sorted_query = "".join(sorted(query))
 
-        if sorted_query not in self._set:
+        if query not in self._set:
             counts = safe_query_counts(query=query, df=df)
 
             if counts is not None and counts == 1:
-                self._set.add(sorted_query)
+                self._set.add(query)
                 self._list.append(query)
 
     def __len__(self):
@@ -275,7 +274,7 @@ def univariate_singling_out_queries(df: pd.DataFrame, n_queries: int) -> List[st
     """
     queries = []
 
-    for col in df.columns:
+    for col in sorted(df.columns):
         if df[col].isna().sum() == 1:
             queries.append(f"{col}.isna()")
 

--- a/tests/test_singling_out_evaluator.py
+++ b/tests/test_singling_out_evaluator.py
@@ -42,11 +42,19 @@ def test_singling_out_queries_unique():
     queries.check_and_append(q2, df=df)
     assert queries.queries == [q1, q2]
 
+
+def test_singling_out_queries_same_characters():
+    df = pd.DataFrame([{"c": 1.2}, {"c": 2.1}])
+
     queries = UniqueSinglingOutQueries()
-    q3, q4 = f"{q1} and {q2}", f"{q2} and {q1}"
-    queries.check_and_append(q3, df=df)
-    queries.check_and_append(q4, df=df)
-    assert queries.queries == [q3]
+    q1, q2 = "c == 1.2", "c == 2.1"
+
+    queries.check_and_append(q1, df=df)
+    queries.check_and_append(q1, df=df)
+    assert queries.queries == [q1]
+
+    queries.check_and_append(q2, df=df)
+    assert queries.queries == [q1, q2]
 
 
 def test_singling_out_queries():
@@ -80,11 +88,7 @@ def test_singling_out_query_generator():
     queries = multivariate_singling_out_queries(df=df, n_queries=2, n_cols=2, max_attempts=None)
     possible_queries = [
         "c1<= 1.23 & c1>= 9.87",
-        "c1<= 1.23 & c0== 'b'",
-        "c1<= 1.23 & c0== 'a'",
         "c1>= 9.87 & c1<= 1.23",
-        "c1>= 9.87 & c0== 'b'",
-        "c1>= 9.87 & c0== 'a'",
         "c0== 'b' & c1<= 1.23",
         "c0== 'b' & c1>= 9.87",
         "c0== 'b' & c0== 'a'",


### PR DESCRIPTION
Do not sort characters in the query, sort columns when constructing the query. Add a test for a previous failure case, adjust existing tests to be in line with the new logic.