### PR TITLE
Upgrade numba version to support python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 description = "Measure singling out, linkability, and inference risk for synthetic data."
 readme = "README.md"
-requires-python = "<3.12, >3.7" # limited by Numba support
+requires-python = "<3.13, >3.9"
 license = {file = "LICENSE.md"}
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -23,10 +23,10 @@ classifiers = [
 
 dependencies = [
     "scikit-learn~=1.2",
-    "numpy >=1.22, <1.27", # limited by Numba support
+    "numpy >=1.22",
     "pandas>=1.4",
     "joblib~=1.2",
-    "numba~=0.58",
+    "numba~=0.59",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
It would be great to run Anonymeter with Python 3.12.

It was previously constrained by numba python support, so this is a fairly conservative update from numba 0.58 to 0.59 which moves anonymeter support to <=3.9, <3.13. 
[Python 3.8 is already end of life](https://devguide.python.org/versions/) so I don't think new versions of Anonymeter need to be supporting anything lower than 3.9.

I have left other dependency versions the same.

Tests passing on 3.12:
```
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-7.4.4, pluggy-1.6.0
rootdir: /Users/daniel.clayton/code/anonymeter
configfile: pyproject.toml
testpaths: tests
collected 152 items

tests/test_confidence.py ....................                            [ 13%]
tests/test_inference_evaluator.py ................................       [ 34%]
tests/test_linkability_evaluator.py .................................... [ 57%]
.........                                                                [ 63%]
tests/test_mixed_types_kneigbors.py ...........                          [ 71%]
tests/test_singling_out_evaluator.py ...............................     [ 91%]
tests/test_transformations.py .......                                    [ 96%]
tests/test_type_detection.py ......                                      [100%]

============================= 152 passed in 3.50s ==============================

```
