### PR TITLE
Support python3.13 and fix CI.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,13 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         # We test only the minimum and the maximum supported versions of python
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
         pandas-version: ["1.4", "2.1"]
+        exclude:
+        - python-version: "3.13"
+          pandas-version: "1.4"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ description of the framework and the attack algorithms can be found in the paper
 
 ## Setup and installation
 
-`Anonymeter` supports Python from 3.9 to 3.12. The simplest way to install `Anonymeter` is from `PyPi`. Simply run
+`Anonymeter` supports Python from 3.9 to 3.13. The simplest way to install `Anonymeter` is from `PyPi`. Simply run
 
 ```
 pip install anonymeter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 description = "Measure singling out, linkability, and inference risk for synthetic data."
 readme = "README.md"
-requires-python = "<3.13, >=3.9"
+requires-python = "<3.14, >=3.9"
 license = {file = "LICENSE.md"}
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR adds support for python3.13 and exclude incompatible python/pandas dependencies from the CI pipeline.